### PR TITLE
fix: allow custom input for "Other" document option

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -19,7 +19,14 @@ body:
                  - label: "`wiki/Changelog.md`"
                  - label: "`ROADMAP.md`"
                  - label: Code comments / doc comments in source files
-                 - label: "Other: ___"
+                 - label: Other (specify below)
+
+     - type: input
+       id: other-doc
+       attributes:
+            label: Other document (if selected above)
+            description: Specify the document if you selected "Other" above
+            placeholder: "e.g., wiki/MyCustomPage.md"
 
      - type: textarea
        id: what-is-wrong


### PR DESCRIPTION
Fixes #3

## Problem
The "Other: ___" option in the documentation issue template was just a checkbox, preventing users from specifying custom document names.

## Solution
Replaced it with:
- Renamed checkbox to "Other (specify below)"
- Added dedicated input field for custom document specification
- Added helpful placeholder text

## After
Users can now enter custom document names like `wiki/MyCustomPage.md` when reporting issues about documents not in the predefined list.

## Example
Before: ☑ Other: ___ (just a checkbox, no input)
After: ☑ Other (specify below) → [text field: e.g., wiki/MyCustomPage.md]