### PR TITLE
fix: Fixes formatting for documentation  and allows Other option, fix…

### DIFF
--- a/.github/ISSUE_TEMPLATE/bready_bug.yml
+++ b/.github/ISSUE_TEMPLATE/bready_bug.yml
@@ -3,75 +3,82 @@ description: Report a reproducible bug specific to the bready Odoo integration b
 title: "[Bug][bready] <short description>"
 labels: [bug, bready]
 body:
-- type: textarea
-  id: describe-bug
-  attributes:
-  label: Describe the bug
-  description: A clear and concise description of what the bug is.
-  validations:
-  required: true
+  - type: textarea
+    id: describe-bug
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is.
+    validations:
+      required: true
 
-- type: textarea
-  id: steps-to-reproduce
-  attributes:
-  label: Steps to reproduce
-  value: |
-  1. Start bready: `./build/bready`
-  2. Invoke `/…` with parameters: `…`
-  3. See error / unexpected behaviour.
-  validations:
-  required: true
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to reproduce
+      value: |
+        1. Start bready: `./build/bready`
+        2. Invoke `/…` with parameters: `…`
+        3. See error / unexpected behaviour.
+    validations:
+      required: true
 
-- type: textarea
-  id: expected-behaviour
-  attributes:
-  label: Expected behaviour
-  description: What you expected to happen.
-  validations:
-  required: true
+  - type: textarea
+    id: expected-behaviour
+    attributes:
+      label: Expected behaviour
+      description: What you expected to happen.
+    validations:
+      required: true
 
-- type: textarea
-  id: actual-behaviour
-  attributes:
-  label: Actual behaviour
-  description: "What actually happened. Paste relevant log output below. ⚠️ Redact all tokens, API keys, passwords, and other secrets."
-  placeholder: "<paste log output here>"
-  validations:
-  required: true
+  - type: textarea
+    id: actual-behaviour
+    attributes:
+      label: Actual behaviour
+      description: "What actually happened. Paste relevant log output below. ⚠️ Redact all tokens, API keys, passwords, and other secrets."
+      placeholder: "<paste log output here>"
+    validations:
+      required: true
 
-- type: checkboxes
-  id: odoo-module
-  attributes:
-  label: Which Odoo module is affected?
-  options:
-  - label: "Projects / Tasks (`/odoo_projects`, `/odoo_tasks`, `/odoo_task_new`)"
-  - label: "To-dos (`/odoo_todos`, `/odoo_todo_new`)"
-  - label: "CRM (`/odoo_crm`)"
-  - label: "Knowledge (`/odoo_notes`)"
-  - label: "Account linking (`/odoo_link`, `/odoo_unlink`, `/odoo_whoami`, …)"
-  - label: "Bridge (`/bridge_*`)"
-  - label: "Role gate (DISCORD_ADMIN_ROLE_ID / DISCORD_MEMBER_ROLE_ID)"
-  - label: Build / CMake
-  - label: "Other: ___"
+  - type: checkboxes
+    id: odoo-module
+    attributes:
+      label: Which Odoo module is affected?
+      options:
+        - label: "Projects / Tasks (`/odoo_projects`, `/odoo_tasks`, `/odoo_task_new`)"
+        - label: "To-dos (`/odoo_todos`, `/odoo_todo_new`)"
+        - label: "CRM (`/odoo_crm`)"
+        - label: "Knowledge (`/odoo_notes`)"
+        - label: "Account linking (`/odoo_link`, `/odoo_unlink`, `/odoo_whoami`, …)"
+        - label: "Bridge (`/bridge_*`)"
+        - label: "Role gate (DISCORD_ADMIN_ROLE_ID / DISCORD_MEMBER_ROLE_ID)"
+        - label: Build / CMake
+        - label: "Other: (Specify below)"
 
-- type: textarea
-  id: environment
-  attributes:
-  label: Environment
-  value: |
-  | Field | Value |
-  |-------|-------|
-  | OS | e.g. Ubuntu 24.04 |
-  | Compiler | e.g. GCC 13 |
-  | CMake version | e.g. 3.28 |
-  | Odoo version | e.g. 18.0 SaaS |
-  | Odoo hosting | SaaS / Self-hosted |
-  | D++ version | e.g. v10.0.35 |
-  validations:
-  required: true
+  - type: input
+    id: other-module
+    attributes:
+      label: Other module (if selected above)
+      description: Specify the module if you selected "Other" above
+      placeholder: "e.g., wiki/MyCustomPage.md"
 
-- type: textarea
-  id: additional-context
-  attributes:
-  label: Additional context
-  description: Screenshots, linked issues, or anything else that helps.
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      value: |
+        | Field | Value |
+        |-------|-------|
+        | OS | e.g. Ubuntu 24.04 |
+        | Compiler | e.g. GCC 13 |
+        | CMake version | e.g. 3.28 |
+        | Odoo version | e.g. 18.0 SaaS |
+        | Odoo hosting | SaaS / Self-hosted |
+        | D++ version | e.g. v10.0.35 |
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Screenshots, linked issues, or anything else that helps.

--- a/.github/ISSUE_TEMPLATE/bready_feature.yml
+++ b/.github/ISSUE_TEMPLATE/bready_feature.yml
@@ -34,8 +34,15 @@ body:
                  - label: Account linking
                  - label: Bridge / Discuss
                  - label: Role-based access control
-                 - label: "New Odoo module integration: ___"
-                 - label: "Other: ___"
+                 - label: "New Odoo module integration: (Specify below)"
+                 - label: "Other: (Specify below)"
+
+     - type: input
+       id: other-module
+       attributes:
+         label: Other module (if selected above)
+         description: Specify the module if you selected "Other" above
+         placeholder: "e.g., Point of Sale"
 
      - type: input
        id: odoo-version

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -19,7 +19,14 @@ body:
                  - label: "`wiki/Changelog.md`"
                  - label: "`ROADMAP.md`"
                  - label: Code comments / doc comments in source files
-                 - label: "Other: ___"
+                 - label: "Other: (Specify below)"
+
+     - type: input
+       id: other-doc
+       attributes:
+         label: Other document (if selected above)
+         description: Specify the document if you selected "Other" above
+         placeholder: "e.g., wiki/MyCustomPage.md"
 
      - type: textarea
        id: what-is-wrong


### PR DESCRIPTION
fixng #3 #17  #18

## Summary

Reformatted some of the documents and added a text option so people can specify what "Other: is.

## Related issue

Closes #3 #17 #18 

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behaviour
  to change)
- [x] Documentation / comment update
- [ ] Refactor / code style improvement

## Pull request checklist

- [x] Code compiles without errors or new warnings
  (`cmake --build build 2>&1 | grep -i "error:"`).
- [x] All new files begin with the copyright header.
- [x] Include guards follow the `BREADY_INCLUDE_<FILENAME>_H_` pattern.
- [x] All new code is inside the appropriate namespace
  (`namespace bready`).
- [x] New or changed public APIs have Google-style doc comments in the
  header file.
- [x] `README.md` updated if new commands or environment
  variables were added.
- [x] Commit message(s) use the imperative mood and are ≤ 72 characters
  on the subject line.

## Testing

Tested creating some simple issues with the templates.